### PR TITLE
Fixing #7 and #11

### DIFF
--- a/Gen3Hex/Model/IFileSystem.cs
+++ b/Gen3Hex/Model/IFileSystem.cs
@@ -50,7 +50,7 @@ namespace HavenSoft.Gen3Hex.Model {
       /// </summary>
       void AddListenerToFile(string fileName, Action<IFileSystem> listener);
 
-      void RemoveAllListenersForFile(string fileName);
+      void RemoveListenerForFile(string fileName, Action<IFileSystem> listener);
 
       /// <summary>
       /// Saves the file without prompting the user for permission.

--- a/Gen3Hex/Model/IFileSystem.cs
+++ b/Gen3Hex/Model/IFileSystem.cs
@@ -1,4 +1,6 @@
-﻿namespace HavenSoft.Gen3Hex.Model {
+﻿using System;
+
+namespace HavenSoft.Gen3Hex.Model {
    public interface IFileSystem {
       string CopyText { get; set; }
 
@@ -33,6 +35,22 @@
       /// If the user cancels or selects an unreadable file, returns null.
       /// </returns>
       LoadedFile OpenFile(params string[] extensionOptions);
+
+      /// <summary>
+      /// Have the filesystem open a specific file.
+      /// </summary>
+      /// <returns>
+      /// If the file exists, it is loaded and returned.
+      /// If it doesn't exist, returns null.
+      /// </returns>
+      LoadedFile LoadFile(string fileName);
+
+      /// <summary>
+      /// When a file changes, the filesystem will call all listeners for that file.
+      /// </summary>
+      void AddListenerToFile(string fileName, Action<IFileSystem> listener);
+
+      void RemoveAllListenersForFile(string fileName);
 
       /// <summary>
       /// Saves the file without prompting the user for permission.

--- a/Gen3Hex/View/App.xaml.cs
+++ b/Gen3Hex/View/App.xaml.cs
@@ -15,8 +15,8 @@ namespace HavenSoft.Gen3Hex.View {
          Solarized.Theme.VariantChanged += (sender, args) => UpdateThemeDictionary();
 
          var fileName = e.Args?.Length == 1 ? e.Args[0] : string.Empty;
-         var viewPort = GetViewModel(fileName);
-         MainWindow = new MainWindow(viewPort);
+         var viewModel = GetViewModel(fileName);
+         MainWindow = new MainWindow(viewModel);
          MainWindow.Show();
       }
 

--- a/Gen3Hex/View/App.xaml.cs
+++ b/Gen3Hex/View/App.xaml.cs
@@ -15,8 +15,10 @@ namespace HavenSoft.Gen3Hex.View {
          Solarized.Theme.VariantChanged += (sender, args) => UpdateThemeDictionary();
 
          var fileName = e.Args?.Length == 1 ? e.Args[0] : string.Empty;
-         var viewModel = GetViewModel(fileName);
+         var fileSystem = new WindowsFileSystem(Dispatcher);
+         var viewModel = GetViewModel(fileName, fileSystem);
          MainWindow = new MainWindow(viewModel);
+         MainWindow.Resources.Add("FileSystem", fileSystem);
          MainWindow.Show();
       }
 
@@ -32,12 +34,11 @@ namespace HavenSoft.Gen3Hex.View {
          Resources.MergedDictionaries.Add(dict);
       }
 
-      private EditorViewModel GetViewModel(string fileName) {
-         var editor = new EditorViewModel(new WindowsFileSystem());
+      private EditorViewModel GetViewModel(string fileName, IFileSystem fileSystem) {
+         var editor = new EditorViewModel(fileSystem);
          if (!File.Exists(fileName)) return editor;
 
-         var bytes = File.ReadAllBytes(fileName);
-         var loadedFile = new LoadedFile(fileName, bytes);
+         var loadedFile = fileSystem.LoadFile(fileName);
          editor.Add(new ViewPort(loadedFile));
          return editor;
       }

--- a/Gen3Hex/View/HexContent.cs
+++ b/Gen3Hex/View/HexContent.cs
@@ -95,15 +95,14 @@ namespace HavenSoft.Gen3Hex.View {
 
       protected override void OnMouseDown(MouseButtonEventArgs e) {
          base.OnMouseDown(e);
-         if (e.ChangedButton == MouseButton.XButton1 && e.XButton1 == MouseButtonState.Pressed && ViewPort.Back.CanExecute(null)) {
+         if (e.ChangedButton == MouseButton.XButton1 && ViewPort.Back.CanExecute(null)) {
             ViewPort.Back.Execute();
             return;
          }
-         if (e.ChangedButton == MouseButton.XButton2 && e.XButton2 == MouseButtonState.Pressed && ViewPort.Forward.CanExecute(null)) {
+         if (e.ChangedButton == MouseButton.XButton2 && ViewPort.Forward.CanExecute(null)) {
             ViewPort.Forward.Execute();
             return;
          }
-         if (e.LeftButton != MouseButtonState.Pressed) return;
          if (e.ChangedButton != MouseButton.Left) return;
          Focus();
          var p = ControlCoordinatesToModelCoordinates(e);

--- a/Gen3Hex/View/HexContent.cs
+++ b/Gen3Hex/View/HexContent.cs
@@ -45,9 +45,7 @@ namespace HavenSoft.Gen3Hex.View {
       }
 
       private void OnViewPortContentChanged(object sender, NotifyCollectionChangedEventArgs e) {
-         // the ViewPort Content can change from a background thread.
-         // make sure we're on the forground thread before messing with the UI state.
-         Dispatcher.BeginInvoke((Action)InvalidateVisual);
+         InvalidateVisual();
       }
 
       private void OnViewPortPropertyChanged(object sender, PropertyChangedEventArgs e) {

--- a/Gen3Hex/View/HexContent.cs
+++ b/Gen3Hex/View/HexContent.cs
@@ -45,6 +45,8 @@ namespace HavenSoft.Gen3Hex.View {
       }
 
       private void OnViewPortContentChanged(object sender, NotifyCollectionChangedEventArgs e) {
+         // the ViewPort Content can change from a background thread.
+         // make sure we're on the forground thread before messing with the UI state.
          Dispatcher.BeginInvoke((Action)InvalidateVisual);
       }
 

--- a/Gen3Hex/View/HexContent.cs
+++ b/Gen3Hex/View/HexContent.cs
@@ -95,6 +95,14 @@ namespace HavenSoft.Gen3Hex.View {
 
       protected override void OnMouseDown(MouseButtonEventArgs e) {
          base.OnMouseDown(e);
+         if (e.ChangedButton == MouseButton.XButton1 && e.XButton1 == MouseButtonState.Pressed && ViewPort.Back.CanExecute(null)) {
+            ViewPort.Back.Execute();
+            return;
+         }
+         if (e.ChangedButton == MouseButton.XButton2 && e.XButton2 == MouseButtonState.Pressed && ViewPort.Forward.CanExecute(null)) {
+            ViewPort.Forward.Execute();
+            return;
+         }
          if (e.LeftButton != MouseButtonState.Pressed) return;
          if (e.ChangedButton != MouseButton.Left) return;
          Focus();

--- a/Gen3Hex/View/HexContent.cs
+++ b/Gen3Hex/View/HexContent.cs
@@ -45,7 +45,7 @@ namespace HavenSoft.Gen3Hex.View {
       }
 
       private void OnViewPortContentChanged(object sender, NotifyCollectionChangedEventArgs e) {
-         InvalidateVisual();
+         Dispatcher.BeginInvoke((Action)InvalidateVisual);
       }
 
       private void OnViewPortPropertyChanged(object sender, PropertyChangedEventArgs e) {

--- a/Gen3Hex/View/HexContent.cs
+++ b/Gen3Hex/View/HexContent.cs
@@ -105,7 +105,11 @@ namespace HavenSoft.Gen3Hex.View {
          }
 
          if (ViewPort is ViewPort editableViewPort) {
-            editableViewPort.SelectionStart = p;
+            if (Keyboard.Modifiers == ModifierKeys.Shift) {
+               editableViewPort.SelectionEnd = p;
+            } else {
+               editableViewPort.SelectionStart = p;
+            }
             CaptureMouse();
          }
       }

--- a/Gen3Hex/View/MainWindow.xaml
+++ b/Gen3Hex/View/MainWindow.xaml
@@ -23,7 +23,8 @@
       <KeyBinding Key="Y" Modifiers="Ctrl" Command="{Binding Redo}" />
       <KeyBinding Key="X" Modifiers="Ctrl" Command="{Binding Cut}" />
       <KeyBinding Key="C" Modifiers="Ctrl" Command="{Binding Copy}" />
-      <KeyBinding Key="P" Modifiers="Ctrl" Command="{Binding Paste}" />
+      <KeyBinding Key="V" Modifiers="Ctrl" Command="{Binding Paste}" />
+      <KeyBinding Key="Delete" Command="{Binding Delete}" />
       <KeyBinding Key="F" Modifiers="Ctrl" Command="{Binding ShowFind}">
          <KeyBinding.CommandParameter>
             <sys:Boolean>true</sys:Boolean>

--- a/Gen3Hex/View/MainWindow.xaml
+++ b/Gen3Hex/View/MainWindow.xaml
@@ -157,7 +157,7 @@
             <DataTemplate>
                <TextBlock Name="TabTextBlock" Background="Transparent" Text="{Binding Name}" Foreground="{DynamicResource Primary}" MouseDown="TabMouseDown" MouseMove="TabMouseMove" MouseUp="TabMouseUp">
                   <TextBlock.InputBindings>
-                     <MouseBinding MouseAction="MiddleClick" Command="{Binding Close}"/>
+                     <MouseBinding MouseAction="MiddleClick" Command="{Binding Close}" CommandParameter="{DynamicResource FileSystem}"/>
                   </TextBlock.InputBindings>
                </TextBlock>
             </DataTemplate>

--- a/Gen3Hex/View/MainWindow.xaml
+++ b/Gen3Hex/View/MainWindow.xaml
@@ -6,6 +6,7 @@
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
         xmlns:solarized="clr-namespace:Solarized;assembly=HavenSoft"
         Icon="..\Snorlax.ico"
+        PreviewMouseDown="RunDeferredActions"
         Title="Gen3Hex" Height="450" Width="800" AllowDrop="True" Background="{DynamicResource Background}">
    <Window.Resources>
       <BooleanToVisibilityConverter x:Key="BoolToVisibility" />

--- a/Gen3Hex/View/MainWindow.xaml.cs
+++ b/Gen3Hex/View/MainWindow.xaml.cs
@@ -1,8 +1,10 @@
 ﻿using HavenSoft.Gen3Hex.Model;
 using HavenSoft.Gen3Hex.ViewModel;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -10,11 +12,14 @@ using System.Windows.Media;
 
 namespace HavenSoft.Gen3Hex.View {
    public partial class MainWindow {
+      private readonly List<Action> deferredActions = new List<Action>();
+
       public EditorViewModel ViewModel { get; }
 
       public MainWindow(EditorViewModel viewModel) {
          InitializeComponent();
          ViewModel = viewModel;
+         viewModel.RequestDelayedWork += (sender, e) => deferredActions.Add(e);
          DataContext = viewModel;
       }
 
@@ -117,6 +122,13 @@ namespace HavenSoft.Gen3Hex.View {
             var selectedElement = (HexContent)GetChild(Tabs, "HexContent", ViewModel[ViewModel.SelectedIndex]);
             Keyboard.Focus(selectedElement);
          }
+      }
+
+      private void RunDeferredActions(object sender, MouseButtonEventArgs e) {
+         if (deferredActions.Count == 0) return;
+         var copy = deferredActions.ToList();
+         deferredActions.Clear();
+         foreach (var action in copy) action();
       }
    }
 }

--- a/Gen3Hex/ViewModel/EditorViewModel.cs
+++ b/Gen3Hex/ViewModel/EditorViewModel.cs
@@ -383,7 +383,6 @@ namespace HavenSoft.Gen3Hex.ViewModel {
 
       private void TabPropertyChanged(object sender, PropertyChangedEventArgs e) {
          if (e.PropertyName == nameof(IViewPort.FileName) && sender is IViewPort viewPort) {
-            if (e.PropertyName != nameof(IViewPort.FileName) || !(sender is IViewPort)) return;
             var args = (ExtendedPropertyChangedEventArgs)e;
             var oldName = (string)args.OldValue;
 

--- a/Gen3Hex/ViewModel/ITabContent.cs
+++ b/Gen3Hex/ViewModel/ITabContent.cs
@@ -22,5 +22,6 @@ namespace HavenSoft.Gen3Hex.ViewModel {
       event EventHandler<string> OnError;
       event EventHandler Closed;
       event EventHandler<ITabContent> RequestTabChange;
+      event EventHandler<Action> RequestDelayedWork;
    }
 }

--- a/Gen3Hex/ViewModel/ITabContent.cs
+++ b/Gen3Hex/ViewModel/ITabContent.cs
@@ -1,12 +1,12 @@
-﻿using HavenSoft.Gen3Hex.Model;
-using System;
+﻿using System;
+using System.ComponentModel;
 using System.Windows.Input;
 
 namespace HavenSoft.Gen3Hex.ViewModel {
    /// <summary>
    /// Each command expects an IFileSystem as its Command Parameter.
    /// </summary>
-   public interface ITabContent {
+   public interface ITabContent : INotifyPropertyChanged {
       string Name { get; }
       ICommand Save { get; }   // parameter: IFileSystem
       ICommand SaveAs { get; } // parameter: IFileSystem

--- a/Gen3Hex/ViewModel/ITabContent.cs
+++ b/Gen3Hex/ViewModel/ITabContent.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using HavenSoft.Gen3Hex.Model;
+using System;
 using System.Windows.Input;
 
 namespace HavenSoft.Gen3Hex.ViewModel {

--- a/Gen3Hex/ViewModel/IViewPort.cs
+++ b/Gen3Hex/ViewModel/IViewPort.cs
@@ -7,6 +7,8 @@ using System.Windows.Input;
 
 namespace HavenSoft.Gen3Hex.ViewModel {
    public interface IViewPort : ITabContent, INotifyCollectionChanged, INotifyPropertyChanged {
+      string FileName { get; } // Name is the name dispayed in a tab. If an IViewPort is tied to a file on disk, return the name.
+
       int Width { get; set; }
       int Height { get; set; }
 

--- a/Gen3Hex/ViewModel/IViewPort.cs
+++ b/Gen3Hex/ViewModel/IViewPort.cs
@@ -2,11 +2,10 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using System.ComponentModel;
 using System.Windows.Input;
 
 namespace HavenSoft.Gen3Hex.ViewModel {
-   public interface IViewPort : ITabContent, INotifyCollectionChanged, INotifyPropertyChanged {
+   public interface IViewPort : ITabContent, INotifyCollectionChanged {
       string FileName { get; } // Name is dispayed in a tab. FileName lets us know when to call 'ConsiderReload'
 
       int Width { get; set; }

--- a/Gen3Hex/ViewModel/IViewPort.cs
+++ b/Gen3Hex/ViewModel/IViewPort.cs
@@ -22,5 +22,6 @@ namespace HavenSoft.Gen3Hex.ViewModel {
       IReadOnlyList<int> Find(string search);
       IChildViewPort CreateChildView(int offset);
       void FollowLink(int x, int y);
+      void ConsiderReload(IFileSystem fileSystem);
    }
 }

--- a/Gen3Hex/ViewModel/IViewPort.cs
+++ b/Gen3Hex/ViewModel/IViewPort.cs
@@ -7,7 +7,7 @@ using System.Windows.Input;
 
 namespace HavenSoft.Gen3Hex.ViewModel {
    public interface IViewPort : ITabContent, INotifyCollectionChanged, INotifyPropertyChanged {
-      string FileName { get; } // Name is the name dispayed in a tab. If an IViewPort is tied to a file on disk, return the name.
+      string FileName { get; } // Name is dispayed in a tab. FileName lets us know when to call 'ConsiderReload'
 
       int Width { get; set; }
       int Height { get; set; }

--- a/Gen3Hex/ViewModel/SearchResultsViewPort.cs
+++ b/Gen3Hex/ViewModel/SearchResultsViewPort.cs
@@ -46,6 +46,7 @@ namespace HavenSoft.Gen3Hex.ViewModel {
       public ObservableCollection<string> Headers { get; } = new ObservableCollection<string>();
       public ICommand Scroll => scroll;
       public string Name { get; }
+      public string FileName => string.Empty;
       public ICommand Save => null;
       public ICommand SaveAs => null;
       public ICommand Undo => null;
@@ -61,6 +62,7 @@ namespace HavenSoft.Gen3Hex.ViewModel {
       public event EventHandler Closed;
       public event NotifyCollectionChangedEventHandler CollectionChanged;
       public event EventHandler<ITabContent> RequestTabChange;
+      public event EventHandler<Action> RequestDelayedWork;
 
       #endregion
 

--- a/Gen3Hex/ViewModel/SearchResultsViewPort.cs
+++ b/Gen3Hex/ViewModel/SearchResultsViewPort.cs
@@ -116,6 +116,8 @@ namespace HavenSoft.Gen3Hex.ViewModel {
          RequestTabChange?.Invoke(this, parent);
       }
 
+      public void ConsiderReload(IFileSystem fileSystem) { }
+
       private void NotifyCollectionChanged() {
          if (children.Count == 0) return;
          UpdateHeaders();

--- a/Gen3Hex/ViewModel/Selection.cs
+++ b/Gen3Hex/ViewModel/Selection.cs
@@ -82,7 +82,11 @@ namespace HavenSoft.Gen3Hex.ViewModel {
                var address = args.ToString();
                if (int.TryParse(address, NumberStyles.HexNumber, CultureInfo.CurrentCulture, out int result)) {
                   backStack.Push(scroll.DataIndex);
-                  forwardStack.Clear();
+                  if (backStack.Count == 1) backward.CanExecuteChanged.Invoke(backward, EventArgs.Empty);
+                  if (forwardStack.Count > 0) {
+                     forward.CanExecuteChanged.Invoke(forward, EventArgs.Empty);
+                     forwardStack.Clear();
+                  }
                   SelectionStart = scroll.DataIndexToViewPoint(result);
                   scroll.ScrollValue += selectionStart.Y;
                } else {
@@ -95,7 +99,9 @@ namespace HavenSoft.Gen3Hex.ViewModel {
             Execute = args => {
                if (backStack.Count == 0) return;
                forwardStack.Push(scroll.DataIndex);
+               if (forwardStack.Count == 1) forward.CanExecuteChanged.Invoke(forward, EventArgs.Empty);
                SelectionStart = scroll.DataIndexToViewPoint(backStack.Pop());
+               if (backStack.Count == 0) backward.CanExecuteChanged.Invoke(backward, EventArgs.Empty);
                scroll.ScrollValue += selectionStart.Y;
             },
          };
@@ -104,11 +110,12 @@ namespace HavenSoft.Gen3Hex.ViewModel {
             Execute = args => {
                if (forwardStack.Count == 0) return;
                backStack.Push(scroll.DataIndex);
+               if (backStack.Count == 1) backward.CanExecuteChanged.Invoke(backward, EventArgs.Empty);
                SelectionStart = scroll.DataIndexToViewPoint(forwardStack.Pop());
+               if (forwardStack.Count == 0) forward.CanExecuteChanged.Invoke(forward, EventArgs.Empty);
                scroll.ScrollValue += selectionStart.Y;
             },
          };
-
       }
 
       public bool IsSelected(Point point) {

--- a/Gen3Hex/ViewModel/ViewModelCore.cs
+++ b/Gen3Hex/ViewModel/ViewModelCore.cs
@@ -10,6 +10,10 @@ namespace HavenSoft.Gen3Hex.ViewModel {
          PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
       }
 
+      protected void NotifyPropertyChanged(object oldValue, [CallerMemberName]string propertyName = null) {
+         PropertyChanged?.Invoke(this, new ExtendedPropertyChangedEventArgs(oldValue, propertyName));
+      }
+
       /// <summary>
       /// Utility function to make writing property updates easier.
       /// If the backing field's value does not match the new value, the backing field is updated and PropertyChanged gets called.
@@ -22,9 +26,15 @@ namespace HavenSoft.Gen3Hex.ViewModel {
       protected bool TryUpdate<T>(ref T backingField, T newValue, [CallerMemberName]string propertyName = null) where T : IEquatable<T> {
          if (backingField == null && newValue == null) return false;
          if (backingField != null && backingField.Equals(newValue)) return false;
+         var oldValue = backingField;
          backingField = newValue;
-         NotifyPropertyChanged(propertyName);
+         NotifyPropertyChanged(oldValue, propertyName);
          return true;
       }
+   }
+
+   public class ExtendedPropertyChangedEventArgs : PropertyChangedEventArgs {
+      public object OldValue { get; }
+      public ExtendedPropertyChangedEventArgs(object oldValue, string propertyName) : base(propertyName) => OldValue = oldValue;
    }
 }

--- a/Gen3Hex/ViewModel/ViewPort.cs
+++ b/Gen3Hex/ViewModel/ViewPort.cs
@@ -33,7 +33,8 @@ namespace HavenSoft.Gen3Hex.ViewModel {
          }
       }
 
-      public string FileName { get; private set; }
+      private string fileName;
+      public string FileName { get => fileName; private set => TryUpdate(ref fileName, value); }
 
       #region Scrolling Properties
 

--- a/Gen3Hex/ViewModel/ViewPort.cs
+++ b/Gen3Hex/ViewModel/ViewPort.cs
@@ -236,7 +236,15 @@ namespace HavenSoft.Gen3Hex.ViewModel {
             var selectionEnd = scroll.ViewPointToDataIndex(selection.SelectionEnd);
             var left = Math.Min(selectionStart, selectionEnd);
             var right = Math.Max(selectionStart, selectionEnd);
-            for (int i = left; i <= right; i++) data[i] = 0xFF;
+            for (int i = left; i <= right; i++) {
+               var p = scroll.DataIndexToViewPoint(i);
+               if (p.Y >= 0 && p.Y < scroll.Height) {
+                  history.CurrentChange[i] = this[p.X, p.Y];
+               } else {
+                  history.CurrentChange[i] = new HexElement(data[i], None.Instance);
+               }
+               data[i] = 0xFF;
+            }
             RefreshBackingData();
          };
 

--- a/Gen3Hex/ViewModel/ViewPort.cs
+++ b/Gen3Hex/ViewModel/ViewPort.cs
@@ -301,6 +301,10 @@ namespace HavenSoft.Gen3Hex.ViewModel {
 
       public void FollowLink(int x, int y) { }
 
+      public void ConsiderReload(IFileSystem fileSystem) {
+         
+      }
+
       private void Edit(char input) {
          var point = GetEditPoint();
          var element = currentView[point.X, point.Y];

--- a/Gen3Hex/ViewModel/ViewPort.cs
+++ b/Gen3Hex/ViewModel/ViewPort.cs
@@ -308,9 +308,14 @@ namespace HavenSoft.Gen3Hex.ViewModel {
 
          try {
             var file = fileSystem.LoadFile(FileName);
+            if (file == null) return; // asked to load the file, but the file wasn't found... carry on
             data = file.Contents;
             scroll.DataLength = data.Length;
             RefreshBackingData();
+
+            // if the new file is shorter, selection might need to be updated
+            // this forces it to be re-evaluated.
+            SelectionStart = SelectionStart;
          } catch (IOException) {
             // something happened when we tried to load the file
             // try again soon.

--- a/HexTests/GeneralAppTests.cs
+++ b/HexTests/GeneralAppTests.cs
@@ -338,7 +338,7 @@ namespace HavenSoft.HexTests {
       public void EditorRemovesFileSystemWatchWhenTabsClose() {
          var fileSystem = new StubFileSystem();
          string name = null;
-         fileSystem.RemoveAllListenersForFile = fileName => name = fileName;
+         fileSystem.RemoveListenerForFile = (fileName, listener) => name = fileName;
          var editor = new EditorViewModel(fileSystem);
          editor.Open.Execute(new LoadedFile("InputFile.txt", new byte[20]));
 
@@ -372,6 +372,20 @@ namespace HavenSoft.HexTests {
 
          Assert.Null(file);
          Assert.Equal(0x05, viewPort[0, 0].Value);
+      }
+
+      [Fact]
+      public void EditorForwardsTabDelayedWork() {
+         void SomeAction() { }
+         Action work = null;
+         var editor = new EditorViewModel(new StubFileSystem());
+         var tab = new StubTabContent();
+         editor.Add(tab);
+
+         editor.RequestDelayedWork += (sender, e) => work = e;
+         tab.RequestDelayedWork.Invoke(tab, SomeAction);
+
+         Assert.Equal(SomeAction, work);
       }
 
       private StubTabContent CreateClosableTab() {

--- a/HexTests/GeneralAppTests.cs
+++ b/HexTests/GeneralAppTests.cs
@@ -1,7 +1,6 @@
 ﻿using HavenSoft.Gen3Hex.Model;
 using HavenSoft.Gen3Hex.ViewModel;
 using System;
-using System.Linq;
 using System.Windows.Input;
 using Xunit;
 

--- a/HexTests/NavigationTests.cs
+++ b/HexTests/NavigationTests.cs
@@ -110,8 +110,14 @@ namespace HavenSoft.HexTests {
       public void GotoIsReversable() {
          var viewPort = new ViewPort(new LoadedFile("test.txt", new byte[0x1000])) { Width = 0x10, Height = 0x10 };
 
+         var changeCount = 0;
+         viewPort.Forward.CanExecuteChanged += (sender, e) => changeCount++;
+
          viewPort.Goto.Execute("000A00");
+         Assert.Equal(0, changeCount);
+
          viewPort.Back.Execute();
+         Assert.Equal(1, changeCount);
 
          Assert.Equal("000000", viewPort.Headers[0]);
       }
@@ -120,9 +126,17 @@ namespace HavenSoft.HexTests {
       public void BackIsReversable() {
          var viewPort = new ViewPort(new LoadedFile("test.txt", new byte[0x1000])) { Width = 0x10, Height = 0x10 };
 
+         var changeCount = 0;
+         viewPort.Back.CanExecuteChanged += (sender, e) => changeCount++;
+
          viewPort.Goto.Execute("000A00");
+         Assert.Equal(1, changeCount);
+
          viewPort.Back.Execute();
+         Assert.Equal(2, changeCount);
+
          viewPort.Forward.Execute();
+         Assert.Equal(3, changeCount);
 
          Assert.Equal("000A00", viewPort.Headers[0]);
       }

--- a/HexTests/ViewPortEditTests.cs
+++ b/HexTests/ViewPortEditTests.cs
@@ -263,6 +263,7 @@ namespace HavenSoft.HexTests {
          viewPort.Clear.Execute();
 
          Assert.Equal(0xFF, viewPort[2, 2].Value);
+         Assert.True(viewPort.Save.CanExecute(new StubFileSystem()));
       }
 
       [Fact]

--- a/HexTests/ViewPortSaveTests.cs
+++ b/HexTests/ViewPortSaveTests.cs
@@ -238,5 +238,19 @@ namespace HavenSoft.HexTests {
 
          Assert.Equal(1, retryCount);
       }
+
+      [Fact]
+      public void ViewPortAdjustsSelectionWhenLoadingAShorterFile() {
+         var viewPort = new ViewPort(new LoadedFile("file.txt", new byte[12]));
+         viewPort.SelectionStart = new Point(3, 3);
+         Assert.Equal(4, viewPort.Width);
+         Assert.Equal(4, viewPort.Height);
+         Assert.Equal(new Point(0, 3), viewPort.SelectionStart);
+
+         var fileSystem = new StubFileSystem { LoadFile = filename => new LoadedFile("file.txt", new byte[10]) };
+         viewPort.ConsiderReload(fileSystem);
+
+         Assert.Equal(new Point(2, 2), viewPort.SelectionStart);
+      }
    }
 }

--- a/HexTests/ViewPortSaveTests.cs
+++ b/HexTests/ViewPortSaveTests.cs
@@ -1,5 +1,6 @@
 ﻿using HavenSoft.Gen3Hex.Model;
 using HavenSoft.Gen3Hex.ViewModel;
+using System.IO;
 using Xunit;
 
 namespace HavenSoft.HexTests {
@@ -223,6 +224,19 @@ namespace HavenSoft.HexTests {
 
          Assert.Equal("newfile", viewPort.Name);
          Assert.Equal(2, nameChangedCount);
+      }
+
+      [Fact]
+      public void ViewPortRequestsDelayedReloadIfReloadFails() {
+         var viewPort = new ViewPort(new LoadedFile("file.txt", new byte[50]));
+         var fileSystem = new StubFileSystem { LoadFile = fileName => throw new IOException() };
+
+         var retryCount = 0;
+         viewPort.RequestDelayedWork += (sender, e) => retryCount++;
+
+         viewPort.ConsiderReload(fileSystem);
+
+         Assert.Equal(1, retryCount);
       }
    }
 }


### PR DESCRIPTION
* Changes to a file opened for edit will be reflected in the file without having to reload.
* If there are local changes, they will not be overwritten.
* No undo support: I could do a full file diff here looking for the changes and building up an undo item from it, but there's no good way to do an undo to an edit to the entire file at this point. More interestingly, the undo-history could be used as a way to "merge" the changes: rewind to last saved state, reload the file from disk, and fast-forward changes back to where we were. It's something to consider for a future change if it's requested.
* Proper validation of the model for this simple bugfix required 6 new unit tests: 2 to validate that the model is adding/removing files to be watched properly, 2 to test the reload functionality, and 2 to test the IOException cases.
* 2 additional tests were added to demonstrate the problems with #11, since that was a related issue.