### PR TITLE
Updates from usability test 1

### DIFF
--- a/src/Gen3Hex.Core/Models/DataFormatModel.cs
+++ b/src/Gen3Hex.Core/Models/DataFormatModel.cs
@@ -378,7 +378,7 @@ namespace HavenSoft.Gen3Hex.Core.Models {
             } else {
                index = ~index;
                if (index < runs.Count) {
-                  runs[index] = kvp.Value;
+                  runs.Insert(index, kvp.Value);
                } else {
                   runs.Add(kvp.Value);
                }
@@ -463,15 +463,19 @@ namespace HavenSoft.Gen3Hex.Core.Models {
             // delete the content, but leave the anchor
             var index = BinarySearch(run.Start);
             changeToken.RemoveRun(run);
-            runs[index] = new NoInfoRun(run.Start, run.PointerSources);
-            changeToken.AddRun(runs[index]);
+            if (run.PointerSources != null) {
+               runs[index] = new NoInfoRun(run.Start, run.PointerSources);
+               changeToken.AddRun(runs[index]);
+            } else {
+               runs.RemoveAt(index);
+            }
          }
       }
 
       private void ClearPointerFormat(DeltaModel changeToken, PointerRun pointerRun) {
          // remove the reference from the anchor we're pointing to as well
          var destination = ReadPointer(pointerRun.Start);
-         if (destination != Pointer.NULL) {
+         if (destination != Pointer.NULL && destination >= 0 && destination < Count) {
             var index = BinarySearch(destination);
             var anchorRun = runs[index];
             var newAnchorRun = anchorRun.RemoveSource(pointerRun.Start);

--- a/src/Gen3Hex.Core/ViewModels/EditorViewModel.cs
+++ b/src/Gen3Hex.Core/ViewModels/EditorViewModel.cs
@@ -178,7 +178,8 @@ namespace HavenSoft.Gen3Hex.Core.ViewModels {
          open.Execute = arg => {
             var file = arg as LoadedFile ?? fileSystem.OpenFile();
             if (file == null) return;
-            Add(new ViewPort(file, new PointerAndStringModel(file.Contents)));
+            var metadata = fileSystem.MetadataFor(file.Name);
+            Add(new ViewPort(file, new PointerAndStringModel(file.Contents, metadata)));
          };
 
          gotoCommand.CanExecute = arg => SelectedTab?.Goto?.CanExecute(arg) ?? false;

--- a/src/Gen3Hex.Core/ViewModels/IToolViewModel.cs
+++ b/src/Gen3Hex.Core/ViewModels/IToolViewModel.cs
@@ -16,27 +16,58 @@ namespace HavenSoft.Gen3Hex.Core.ViewModels {
 
    public class ToolTray : ViewModelCore, IToolTrayViewModel {
       private readonly IList<IToolViewModel> tools;
-      private readonly StubCommand stringToolCommand;
+      private readonly StubCommand hideCommand;
+      private readonly StubCommand stringToolCommand, tool2Command, tool3Command;
 
       private int selectedIndex;
       public int SelectedIndex {
          get => selectedIndex;
-         set => TryUpdate(ref selectedIndex, value);
+         set {
+            if (TryUpdate(ref selectedIndex, value)) {
+               hideCommand.CanExecuteChanged.Invoke(hideCommand, EventArgs.Empty);
+            }
+         }
       }
 
       public int Count => tools.Count;
       public IToolViewModel this[int index] => tools[index];
-      public PCSTool StringTool => (PCSTool)tools[0];
+
+      public ICommand HideCommand => hideCommand;
       public ICommand StringToolCommand => stringToolCommand;
+      public ICommand Tool2Command => tool2Command;
+      public ICommand Tool3Command => tool3Command;
+
+      public PCSTool StringTool => (PCSTool)tools[0];
+
+      public IToolViewModel Tool2 => tools[1];
+
+      public IToolViewModel Tool3 => tools[2];
 
       public ToolTray(IModel model, ChangeHistory<DeltaModel> history) {
-         tools = new[] {
+         tools = new IToolViewModel[] {
             new PCSTool(model, history),
+            new FillerTool("Tool2"),
+            new FillerTool("Tool3"),
          };
 
          stringToolCommand = new StubCommand {
             CanExecute = ICommandExtensions.CanAlwaysExecute,
             Execute = arg => SelectedIndex = selectedIndex == 0 ? -1 : 0,
+         };
+
+         tool2Command = new StubCommand {
+            CanExecute = ICommandExtensions.CanAlwaysExecute,
+            Execute = arg => SelectedIndex = selectedIndex == 1 ? -1 : 1,
+         };
+
+         tool3Command = new StubCommand {
+            CanExecute = ICommandExtensions.CanAlwaysExecute,
+            Execute = arg => SelectedIndex = selectedIndex == 2 ? -1 : 2,
+         };
+
+         hideCommand = new StubCommand {
+            CanExecute = arg => SelectedIndex != -1,
+            Execute = arg => SelectedIndex = -1,
          };
 
          SelectedIndex = -1;
@@ -98,5 +129,11 @@ namespace HavenSoft.Gen3Hex.Core.ViewModels {
       public event EventHandler<(int originalLocation, int newLocation)> ModelDataMoved;
 
       public PCSTool(IModel model, ChangeHistory<DeltaModel> history) => (this.model, this.history) = (model, history);
+   }
+
+   public class FillerTool : IToolViewModel {
+      public string Name { get; }
+      public FillerTool(string name) { Name = name; }
+      public event PropertyChangedEventHandler PropertyChanged;
    }
 }

--- a/src/Gen3Hex.Core/ViewModels/IViewPort.cs
+++ b/src/Gen3Hex.Core/ViewModels/IViewPort.cs
@@ -28,6 +28,7 @@ namespace HavenSoft.Gen3Hex.Core.ViewModels {
       IReadOnlyList<int> Find(string search);
       IChildViewPort CreateChildView(int offset);
       void FollowLink(int x, int y);
+      void ExpandSelection();
       void ConsiderReload(IFileSystem fileSystem);
       void FindAllSources(int x, int y);
 

--- a/src/Gen3Hex.Core/ViewModels/SearchResultsViewPort.cs
+++ b/src/Gen3Hex.Core/ViewModels/SearchResultsViewPort.cs
@@ -139,6 +139,8 @@ namespace HavenSoft.Gen3Hex.Core.ViewModels {
          RequestTabChange?.Invoke(this, parent);
       }
 
+      public void ExpandSelection() { }
+
       public void ConsiderReload(IFileSystem fileSystem) { }
 
       public void FindAllSources(int x, int y) {

--- a/src/Gen3Hex.Tests/ToolTests.cs
+++ b/src/Gen3Hex.Tests/ToolTests.cs
@@ -1,4 +1,5 @@
-﻿using HavenSoft.Gen3Hex.Core.Models;
+﻿using HavenSoft.Gen3Hex.Core;
+using HavenSoft.Gen3Hex.Core.Models;
 using HavenSoft.Gen3Hex.Core.ViewModels;
 using HavenSoft.Gen3Hex.Core.ViewModels.DataFormats;
 using System.Collections.Generic;
@@ -79,6 +80,18 @@ namespace HavenSoft.Gen3Hex.Tests {
          viewPort.Tools.StringTool.Content = "Some "; // removed 'Text' from the end
 
          Assert.Equal(0xFF, model[7]);
+      }
+
+      [Fact]
+      public void HideCommandClosesAnyOpenTools() {
+         var model = new PointerAndStringModel(new byte[0x200]);
+         var history = new ChangeHistory<DeltaModel>(null);
+         var tools = new ToolTray(model, history);
+
+         tools.SelectedIndex = 1;
+         tools.HideCommand.Execute();
+
+         Assert.Equal(-1, tools.SelectedIndex);
       }
    }
 }

--- a/src/Gen3Hex.Tests/ViewPortCursorTests.cs
+++ b/src/Gen3Hex.Tests/ViewPortCursorTests.cs
@@ -209,5 +209,22 @@ namespace HavenSoft.Gen3Hex.Tests {
 
          Assert.Equal(new Point(0, 2), selection.SelectionEnd);
       }
+
+      [Fact]
+      public void CanExpandSelection() {
+         var data = new byte[0x200];
+         var model = new PointerAndStringModel(data);
+         var viewPort = new ViewPort(new LoadedFile("test.txt", data), model) { Width = 0x10, Height = 0x10 };
+
+         viewPort.Edit("<000100>");
+         viewPort.SelectionStart = new Point(1, 0);
+         viewPort.ExpandSelection();
+
+         Assert.True(viewPort.IsSelected(new Point(0, 0)));
+         Assert.True(viewPort.IsSelected(new Point(1, 0)));
+         Assert.True(viewPort.IsSelected(new Point(2, 0)));
+         Assert.True(viewPort.IsSelected(new Point(3, 0)));
+         Assert.False(viewPort.IsSelected(new Point(4, 0)));
+      }
    }
 }

--- a/src/Gen3Hex.WPF/Windows/MainWindow.xaml
+++ b/src/Gen3Hex.WPF/Windows/MainWindow.xaml
@@ -152,6 +152,13 @@
                <MenuItem Header="_Toggle Theme" Click="ToggleTheme" InputGestureText="Ctrl+T"/>
                <MenuItem Header="_Clear Error" Command="{Binding ClearError}" InputGestureText="Esc"/>
             </MenuItem>
+            <MenuItem Header="_Tools">
+               <MenuItem Header="_Hide All Tools" Command="{Binding Tools.HideCommand}"/>
+               <Separator/>
+               <MenuItem Header="Toggle _String Tool" Command="{Binding Tools.StringToolCommand}"/>
+               <MenuItem Header="Toggle _Filler Tool" Command="{Binding Tools.Tool2Command}"/>
+               <MenuItem Header="Toggle _Extra Tool" Command="{Binding Tools.Tool3Command}"/>
+            </MenuItem>
             <MenuItem Header="_Help">
                <MenuItem Header="_Wiki" Click="WikiClick"/>
                <MenuItem Header="_Report an Issue" Click="ReportIssueClick"/>
@@ -184,10 +191,47 @@
                   </ItemsControl>
                   <Line Width="1" DockPanel.Dock="Left" Stroke="{DynamicResource Background}"/>
                   <StackPanel DockPanel.Dock="Right" Visibility="{Binding HasTools, Converter={StaticResource BoolToVisibility}}">
-                     <Button Content="String" Command="{Binding Tools.StringToolCommand}">
+                     <Button Content="String" Command="{Binding Tools.StringToolCommand}" Margin="0,2">
                         <Button.LayoutTransform>
                            <RotateTransform Angle="90"/>
                         </Button.LayoutTransform>
+                        <Button.Style>
+                           <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                              <Style.Triggers>
+                                 <DataTrigger Binding="{Binding Tools.SelectedIndex}" Value="0">
+                                    <Setter Property="BorderBrush" Value="{solarized:Theme Blue}"/>
+                                 </DataTrigger>
+                              </Style.Triggers>
+                           </Style>
+                        </Button.Style>
+                     </Button>
+                     <Button Content="Tool2" Command="{Binding Tools.Tool2Command}" Margin="0,2">
+                        <Button.LayoutTransform>
+                           <RotateTransform Angle="90"/>
+                        </Button.LayoutTransform>
+                        <Button.Style>
+                           <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                              <Style.Triggers>
+                                 <DataTrigger Binding="{Binding Tools.SelectedIndex}" Value="1">
+                                    <Setter Property="BorderBrush" Value="{solarized:Theme Blue}"/>
+                                 </DataTrigger>
+                              </Style.Triggers>
+                           </Style>
+                        </Button.Style>
+                     </Button>
+                     <Button Content="Tool3" Command="{Binding Tools.Tool3Command}" Margin="0,2">
+                        <Button.LayoutTransform>
+                           <RotateTransform Angle="90"/>
+                        </Button.LayoutTransform>
+                        <Button.Style>
+                           <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                              <Style.Triggers>
+                                 <DataTrigger Binding="{Binding Tools.SelectedIndex}" Value="2">
+                                    <Setter Property="BorderBrush" Value="{solarized:Theme Blue}"/>
+                                 </DataTrigger>
+                              </Style.Triggers>
+                           </Style>
+                        </Button.Style>
                      </Button>
                   </StackPanel>
                   <Grid DockPanel.Dock="Right" DataContext="{Binding Tools}">
@@ -211,8 +255,36 @@
                               </Style.Triggers>
                            </Style>
                         </StackPanel.Style>
-                        <TextBox Text="{Binding StringTool.Address, Converter={StaticResource Hex}}" Margin="5,15"/>
-                        <TextBox FontFamily="Consolas" Text="{Binding StringTool.Content, UpdateSourceTrigger=PropertyChanged}" Margin="5,15" AcceptsReturn="True" MinHeight="50" Width="255" TextWrapping="Wrap"/>
+                        <TextBlock Text="Address:" Margin="5,15,0,0"/>
+                        <TextBox Text="{Binding StringTool.Address, Converter={StaticResource Hex}}" Margin="5"/>
+                        <TextBlock Text="Content:" Margin="5,30,0,0"/>
+                        <TextBox FontFamily="Consolas" Text="{Binding StringTool.Content, UpdateSourceTrigger=PropertyChanged}" Margin="5,5" AcceptsReturn="True" MinHeight="50" Width="255" TextWrapping="Wrap"/>
+                     </StackPanel>
+                     <StackPanel Name="Tool2Panel">
+                        <StackPanel.Style>
+                           <Style TargetType="StackPanel">
+                              <Setter Property="Visibility" Value="Collapsed"/>
+                              <Style.Triggers>
+                                 <DataTrigger Binding="{Binding SelectedIndex}" Value="1">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                 </DataTrigger>
+                              </Style.Triggers>
+                           </Style>
+                        </StackPanel.Style>
+                        <TextBlock Text="Coming Soon!" Margin="5,15,0,0"/>
+                     </StackPanel>
+                     <StackPanel Name="Tool3Panel">
+                        <StackPanel.Style>
+                           <Style TargetType="StackPanel">
+                              <Setter Property="Visibility" Value="Collapsed"/>
+                              <Style.Triggers>
+                                 <DataTrigger Binding="{Binding SelectedIndex}" Value="2">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                 </DataTrigger>
+                              </Style.Triggers>
+                           </Style>
+                        </StackPanel.Style>
+                        <TextBlock Text="Coming Soon!" Margin="5,15,0,0"/>
                      </StackPanel>
                   </Grid>
                   <ScrollBar DockPanel.Dock="Right"


### PR DESCRIPTION
- move "follow link" interaction from double-click to Ctrl+Click and add a matching right-click option
create a new interaction, "expand selection", and map it to double-click
- fix a crash involving clearing out pointers that point outside the length of the file
- fix a bug where modifying / removing a pointer could muck with the format of nearby pointers
- make it so that editing bytes via standard hex characters on the keyboard would jump to editing the first byte in a pointer instead of the middle of it, and auto-clear the pointer on commit of the text change
- add some new dummy tools so that the future state of the tools is a bit easier to understand
- tools deserves its own entry in the menu
- string tool textboxes need labels
- add tests for everything